### PR TITLE
Fix doctrine-extra skeleton package identity and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ https://examples.contributte.org/doctrine-skeleton/
 
 ## Installation
 
-To install latest version of `contributte/doctrine-skeleton` use [Composer](https://getcomposer.org).
+To install latest version of `contributte/doctrine-extra-skeleton` use [Composer](https://getcomposer.org).
 
 ```
-composer create-project -s dev contributte/doctrine-skeleton acme
+composer create-project -s dev contributte/doctrine-extra-skeleton acme
 ```
 
 ### Install using [docker](https://github.com/docker/docker/)
@@ -55,7 +55,7 @@ composer create-project -s dev contributte/doctrine-skeleton acme
 1) At first, use composer to install this project.
 
    ```
-   composer create-project -s dev contributte/doctrine-skeleton
+   composer create-project -s dev contributte/doctrine-extra-skeleton
    ```
 
 2) After that, you have to setup Postgres >= 12 database. You can start it manually or use docker image `dockette/postgres:12`.
@@ -93,12 +93,12 @@ composer create-project -s dev contributte/doctrine-skeleton acme
 
 6) Open http://localhost:8000 and enjoy!
 
-### Install using [docker-compose](https://https://github.com/docker/compose/)
+### Install using [docker-compose](https://github.com/docker/compose/)
 
 1) At first, use composer to install this project.
 
    ```
-   composer create-project -s dev contributte/webapp-project
+   composer create-project -s dev contributte/webapp-skeleton
    ```
 
 2) Modify `config/local.neon` and set host to `database`

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "contributte/doctrine-skeleton",
-  "description": "Nette and Doctrine project skeleton. Using Doctrine (@nettrine) and Contributte (@contributte) libraries by @f3l1x.",
+  "name": "contributte/doctrine-extra-skeleton",
+  "description": "Advanced Nette and Doctrine project skeleton with an expanded set of Nettrine and Contributte integrations. Using Doctrine (@nettrine) and Contributte (@contributte) libraries by @f3l1x.",
   "keywords": [
     "php",
     "nette",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ce70fe483314fd6a4560c55e5c4c638",
+    "content-hash": "d64408483e815e6e85b3303d224dea14",
     "packages": [
         {
             "name": "contributte/application",
@@ -6396,12 +6396,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary
- correct composer package name to contributte/doctrine-extra-skeleton
- update README composer create-project commands to target contributte/doctrine-extra-skeleton
- replace outdated contributte/webapp-project reference with contributte/webapp-skeleton and fix docker-compose docs URL typo

## Why
- repository metadata and docs currently point to other package names, causing confusion and failed onboarding commands
- this aligns package identity and installation instructions with the actual repository