### PR TITLE
Use php for coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary

Replace `phpdbg` with plain `php` in the `coverage` Makefile target so this skeleton matches the org-wide coverage runner migration tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. Updating the skeleton keeps new projects aligned with that change.

## Changes

- replace `-p phpdbg` with `-p php` in `Makefile`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification attempted: `make coverage` now invokes `php`, but the run currently crashes in `vendor/nette/tester` with `Using null as an array offset is deprecated` under PHP 8.4